### PR TITLE
Set initial value for active.

### DIFF
--- a/src/adaptive-scroll.js
+++ b/src/adaptive-scroll.js
@@ -7,7 +7,7 @@ adaptive.factory('$gyroscope', ['$rootScope', function ($rootScope) {
   var alphaStart, betaStart, gammaStart;
   var alpha, beta, gamma;
   var trashold = 20;
-  var active;
+  var active = false;
   var onalpha;
   var onbeta;
   var ongamma;


### PR DESCRIPTION
It seems that 'active' should be set during definition as it is used in handler which is set up before possible assignments.
